### PR TITLE
Make error handling more principled and future proof

### DIFF
--- a/statefun-example/Cargo.toml
+++ b/statefun-example/Cargo.toml
@@ -13,8 +13,7 @@ homepage = "https://github.com/aljoscha/statefun-rust"
 repository = "https://github.com/aljoscha/statefun-rust.git"
 
 [dependencies]
-failure = "0.1.5"
-exitfailure = "0.5.1"
+anyhow = "1.0"
 log = "0.4.8"
 env_logger = "0.7.1"
 statefun = { path = "../statefun-sdk", version = "0.1.1" }

--- a/statefun-example/src/main.rs
+++ b/statefun-example/src/main.rs
@@ -1,4 +1,3 @@
-use exitfailure::ExitFailure;
 use protobuf::well_known_types::Int32Value;
 
 use statefun::io::kafka::KafkaEgress;
@@ -59,7 +58,7 @@ pub fn relay(_context: Context, message: GreetResponse) -> Effects {
     effects
 }
 
-fn main() -> Result<(), ExitFailure> {
+fn main() -> anyhow::Result<()> {
     env_logger::init();
 
     let mut function_registry = FunctionRegistry::new();

--- a/statefun-sdk/Cargo.toml
+++ b/statefun-sdk/Cargo.toml
@@ -13,11 +13,13 @@ homepage = "https://github.com/aljoscha/statefun-rust"
 repository = "https://github.com/aljoscha/statefun-rust.git"
 
 [dependencies]
-failure = "0.1.5"
-exitfailure = "0.5.1"
+thiserror = "1.0"
 log = "0.4.8"
 tokio = { version = "0.2", features = ["full"] }
 hyper = "0.13"
 bytes = "0.5"
 protobuf = "2.15"
 statefun-proto = { path = "../statefun-proto", version = "0.1.1" }
+
+[dev-dependencies]
+anyhow = "1.0"

--- a/statefun-sdk/src/error.rs
+++ b/statefun-sdk/src/error.rs
@@ -1,0 +1,19 @@
+use protobuf::ProtobufError;
+use thiserror::Error;
+
+use crate::FunctionType;
+
+/// Errors that can occur during function invocation.
+///
+/// These mostly forward underlying errors from serialization or Protobuf.
+#[derive(Error, Debug)]
+#[non_exhaustive]
+pub enum InvocationError {
+    /// There was no function registered for the given `FunctionType`.
+    #[error("function {0} not found in registry")]
+    FunctionNotFound(FunctionType),
+
+    /// Something went wrong with Protobuf parsing, writing, packing, or unpacking.
+    #[error(transparent)]
+    ProtobufError(#[from] ProtobufError),
+}

--- a/statefun-sdk/src/lib.rs
+++ b/statefun-sdk/src/lib.rs
@@ -56,14 +56,16 @@ use std::fmt::{Display, Formatter};
 use std::time::Duration;
 
 use protobuf::well_known_types::Any;
-use protobuf::{Message, ProtobufError};
-use thiserror::Error;
+use protobuf::Message;
 
+pub use error::InvocationError;
 pub use function_registry::FunctionRegistry;
 use statefun_proto::http_function::Address as ProtoAddress;
 
+mod error;
 mod function_registry;
 mod invocation_bridge;
+
 pub mod io;
 pub mod transport;
 
@@ -299,19 +301,4 @@ impl Display for EgressIdentifier {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "EgressIdentifier {}/{}", self.namespace, self.name)
     }
-}
-
-/// Errors that can occur during function invocation.
-///
-/// These mostly forward underlying errors from serialization or Protobuf.
-#[derive(Error, Debug)]
-#[non_exhaustive]
-pub enum InvocationError {
-    /// There was no function registered for the given `FunctionType`.
-    #[error("function {0} not found in registry")]
-    FunctionNotFound(FunctionType),
-
-    /// Something went wrong with Protobuf parsing, writing, packing, or unpacking.
-    #[error(transparent)]
-    ProtobufError(#[from] ProtobufError),
 }

--- a/statefun-sdk/src/transport.rs
+++ b/statefun-sdk/src/transport.rs
@@ -7,7 +7,10 @@ pub mod hyper;
 /// Serves up stateful functions in a [FunctionRegistry](crate::FunctionRegistry) to make them
 /// invokable in a Statefun deployment.
 pub trait Transport {
+    /// The error type this `Transport` might generate.
+    type Error;
+
     /// Serves the stateful functions in the given `FunctionRegistry`. This will usually be a
     /// blocking method and should be the last method you call in your program.
-    fn run(self, function_registry: FunctionRegistry) -> Result<(), failure::Error>;
+    fn run(self, function_registry: FunctionRegistry) -> Result<(), Self::Error>;
 }


### PR DESCRIPTION
We use thiserror to define proper errors types for errors that are
exposed in the API.

We also annotate the errors as #[non_exhaustive] to make sure that we
can extend them in the future.

For the example we use anyhow.

Background info: failure was deprecated and anyhow and thiserror are
suggested as replacements going forward.

Fixes #6